### PR TITLE
ci: fixup caches

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 
 jobs:
   depends:
@@ -46,13 +45,23 @@ jobs:
           key: depends-base-${{ runner.os }}-${{ hashFiles('bitcoin/depends/packages/*.mk') }}
           restore-keys: depends-base-${{ runner.os }}-
 
+      - name: Set up ccache key
+        id: ccache_key
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "key=depends-ccache-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=depends-ccache-master" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-linux-${{ github.sha }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ccache-x86_64-linux-
+            depends-ccache-master-
+            depends-ccache-
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 
 jobs:
   check:
@@ -43,12 +42,22 @@ jobs:
           path: bitcoin
           fetch-depth: 1
 
+      - name: Set up ccache key
+        id: ccache_key
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "key=ccache-${{ matrix.system }}-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=ccache-${{ matrix.system }}-master" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.system }}-${{ github.sha }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
+            ccache-${{ matrix.system }}-master
             ccache-${{ matrix.system }}-
 
       - name: Install Nix


### PR DESCRIPTION
Currently we are seeing large cache misses between PRs and pushes to master. Address this by sharing ccaches a little more liberally.

Now we try to restore with the following precedence (as applicable):

1. Specific PR
2. Current master
3. Anything else we can find