### PR TITLE
Remove BDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ We use a slightly opinionated Clang/LLVM-based build system:
 
 All Bitcoin Core dependencies from nixpkgs:
 - Boost
-- Berkeley DB 4.x (legacy only now)
 - libevent
 - SQLite
 - ZeroMQ

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,6 @@
         [
           boost
           capnproto
-          db4
           libevent
           qrencode
           sqlite.dev


### PR DESCRIPTION
Support for this has now been droped for Bitcoin Core v30.0.

Remove the package and update the readme.