### PR TITLE
Remove unneeded shellhook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,11 +103,6 @@
           ]
           ++ platformPkgs isLinux [pkgs.gdb]
           ++ platformPkgs isDarwin [llvmTools.lldb];
-
-        shellHook = ''
-          # This can likely be removed if https://github.com/bitcoin/bitcoin/pull/32678 is merged
-          unset SOURCE_DATE_EPOCH
-        '';
         inherit (env) CMAKE_GENERATOR LD_LIBRARY_PATH LOCALE_ARCHIVE;
       };
 


### PR DESCRIPTION
Now that the upstream pull was merged, we can remove the shellhook here.