### PR TITLE
Various fixups

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix fmt . 2>/dev/null
+
+changed=$(git diff --name-only)
+if [ -n "$changed" ]; then
+    echo "nix fmt modified files:"
+    echo "$changed"
+    echo ""
+    echo "Stage the changes and retry your commit."
+    exit 1
+fi

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -80,32 +80,8 @@ jobs:
         run: nix flake check
 
       - name: Build bitcoin from depends
-        run: |
-          nix develop .#depends --command bash -c "
-            set -eux
-
-            export CCACHE_DIR=${{ env.CCACHE_DIR }}
-            export SOURCES_PATH=${{ env.SOURCES_PATH }}
-            export BASE_CACHE=${{ env.BASE_CACHE }}
-
-            cd bitcoin
-            HOST_TRIPLET=\$(./depends/config.guess)
-            export HOST_TRIPLET
-#
-            # Nix sets CC/CXX to bare names (e.g. 'clang'), relying on PATH.
-            # The depends Makefile substitutes CC/CXX into toolchain.cmake,
-            # but cmake's find_program searches system dirs before PATH,
-            # so a bare 'clang' resolves to /usr/bin/clang (system) instead
-            # of the Nix clang. This causes glibc version mismatches: Nix
-            # compiles against glibc 2.42 headers, but the system linker
-            # links against the runner's older glibc, producing undefined
-            # references to fortified symbols like __inet_pton_chk.
-            # Resolve to absolute Nix store paths to avoid this.
-            NIX_CC=\$(command -v \$CC)
-            NIX_CXX=\$(command -v \$CXX)
-            make -C depends -j\$(nproc) NO_QT=1 CC="\$NIX_CC" CXX="\$NIX_CXX" build_CC="\$NIX_CC" build_CXX="\$NIX_CXX"
-
-            cmake -B build --toolchain \"depends/\$HOST_TRIPLET/toolchain.cmake\"
-            cmake --build build -j\$(nproc)
-            ccache --show-stats
-          "
+        env:
+          CCACHE_DIR: ${{ env.CCACHE_DIR }}
+          SOURCES_PATH: ${{ env.SOURCES_PATH }}
+          BASE_CACHE: ${{ env.BASE_CACHE }}
+        run: nix develop .#depends --command ./scripts/build-depends.sh

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -91,7 +91,20 @@ jobs:
             cd bitcoin
             HOST_TRIPLET=\$(./depends/config.guess)
             export HOST_TRIPLET
-            make -C depends -j\$(nproc) NO_QT=1 build_CC="$CC" build_CXX="$CXX"
+#
+            # Nix sets CC/CXX to bare names (e.g. 'clang'), relying on PATH.
+            # The depends Makefile substitutes CC/CXX into toolchain.cmake,
+            # but cmake's find_program searches system dirs before PATH,
+            # so a bare 'clang' resolves to /usr/bin/clang (system) instead
+            # of the Nix clang. This causes glibc version mismatches: Nix
+            # compiles against glibc 2.42 headers, but the system linker
+            # links against the runner's older glibc, producing undefined
+            # references to fortified symbols like __inet_pton_chk.
+            # Resolve to absolute Nix store paths to avoid this.
+            NIX_CC=\$(command -v \$CC)
+            NIX_CXX=\$(command -v \$CXX)
+            make -C depends -j\$(nproc) NO_QT=1 CC="\$NIX_CC" CXX="\$NIX_CXX" build_CC="\$NIX_CC" build_CXX="\$NIX_CXX"
+
             cmake -B build --toolchain \"depends/\$HOST_TRIPLET/toolchain.cmake\"
             cmake --build build -j\$(nproc)
             ccache --show-stats

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -85,17 +85,4 @@ jobs:
         run: nix flake check
 
       - name: Build bitcoind
-        run: |
-          nix develop --command bash -c "
-            set -eux
-            export CCACHE_DIR=${{ env.CCACHE_DIR }}
-            cd bitcoin
-            cmake -B build \
-              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              --preset dev-mode \
-              -DBUILD_GUI=OFF \
-              ${{ matrix.cmake_flags }}
-            cmake --build build -j${{ matrix.cores }}
-            ccache --show-stats
-          "
+        run: nix develop --command ./scripts/build-systemlibs.sh ${{ matrix.cores }} ${{ matrix.cmake_flags }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,8 +28,8 @@ jobs:
             cores: 4
             cmake_flags:
           - system: x86_64-darwin
-            runner_label: macos-15-intel
-            cores: 4
+            runner_label: macos-latest
+            cores: 3
             cmake_flags: -DWITH_USDT=OFF
           - system: aarch64-darwin
             runner_label: macos-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -94,6 +94,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               --preset dev-mode \
+              -DBUILD_GUI=OFF \
               ${{ matrix.cmake_flags }}
             cmake --build build -j${{ matrix.cores }}
             ccache --show-stats

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773122722,
-        "narHash": "sha256-FIqHByVqxCprNjor1NqF80F2QQoiiyqanNNefdlvOg4=",
+        "lastModified": 1773734432,
+        "narHash": "sha256-IF5ppUWh6gHGHYDbtVUyhwy/i7D261P7fWD1bPefOsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62dc67aa6a52b4364dd75994ec00b51fbf474e50",
+        "rev": "cda48547b432e8d3b18b4180ba07473762ec8558",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768886240,
-        "narHash": "sha256-C2TjvwYZ2VDxYWeqvvJ5XPPp6U7H66zeJlRaErJKoEM=",
+        "lastModified": 1773122722,
+        "narHash": "sha256-FIqHByVqxCprNjor1NqF80F2QQoiiyqanNNefdlvOg4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80e4adbcf8992d3fd27ad4964fbb84907f9478b0",
+        "rev": "62dc67aa6a52b4364dd75994ec00b51fbf474e50",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -83,10 +83,10 @@
               else
                 llvmPackages.stdenv;
           in
-          if isLinux then
-            pkgs.stdenvAdapters.useMoldLinker (pkgs.ccacheStdenv.override { stdenv = llvmStdenv; })
-          else
-            pkgs.ccacheStdenv.override { stdenv = llvmStdenv; };
+          let
+            moldStdenv = if isLinux then pkgs.stdenvAdapters.useMoldLinker llvmStdenv else llvmStdenv;
+          in
+            pkgs.ccacheStdenv.override { stdenv = moldStdenv; };
 
         pythonEnv = python.withPackages (
           ps:

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,20 @@
                 }
             '';
 
+        patchelf-releases = pkgs.writeShellApplication {
+          name = "patchelf-releases";
+          runtimeInputs = with pkgs; [
+            patchelf
+            file
+            findutils
+            gnugrep
+          ];
+          text = builtins.replaceStrings
+            [ "@interp@" ]
+            [ "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" ]
+            (builtins.readFile ./scripts/patchelf-releases.sh);
+        };
+
         stdEnv =
           let
             llvmStdenv =
@@ -137,8 +151,14 @@
               pkgs.ruff
               pkgs.ty
               pythonEnv
+              # vouch
+              pkgs.gh
+              pkgs.nodePackages.prettier
+              pkgs.nushell
+              pkgs.pinact
             ]
             ++ lib.optionals isLinux [
+              patchelf-releases
               pkgs.gdb
               pkgs.valgrind
             ]

--- a/flake.nix
+++ b/flake.nix
@@ -65,10 +65,9 @@
             findutils
             gnugrep
           ];
-          text = builtins.replaceStrings
-            [ "@interp@" ]
-            [ "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" ]
-            (builtins.readFile ./scripts/patchelf-releases.sh);
+          text = builtins.replaceStrings [ "@interp@" ] [ "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" ] (
+            builtins.readFile ./scripts/patchelf-releases.sh
+          );
         };
 
         stdEnv =
@@ -162,7 +161,7 @@
       in
       {
         devShells.default = mkDevShell nativeBuildInputs buildInputs;
-        devShells.depends = (mkDevShell nativeBuildInputs).overrideAttrs (oldAttrs: {
+        devShells.depends = (mkDevShell nativeBuildInputs [ ]).overrideAttrs (oldAttrs: {
           # Set these to force depends capnp to also use clang, otherwise it
           # fails when looking for the default (gcc/g++)
           build_CC = "clang";

--- a/flake.nix
+++ b/flake.nix
@@ -122,17 +122,11 @@
           pkgs.linuxPackages.bpftrace
         ];
 
-        qtBuildInputs = [
-          pkgs.qt6.qtbase # https://nixos.org/manual/nixpkgs/stable/#sec-language-qt
-          pkgs.qt6.qttools
-        ];
-
         # Will exist in the runtime environment
         buildInputs = [
           pkgs.boost
           pkgs.capnproto
           pkgs.libevent
-          pkgs.qrencode
           pkgs.sqlite.dev
           pkgs.zeromq
         ];
@@ -152,11 +146,6 @@
               pkgs.ruff
               pkgs.ty
               pythonEnv
-              # vouch
-              pkgs.gh
-              pkgs.nodePackages.prettier
-              pkgs.nushell
-              pkgs.pinact
             ]
             ++ lib.optionals isLinux [
               patchelf-releases
@@ -172,10 +161,8 @@
           };
       in
       {
-        devShells.default = mkDevShell nativeBuildInputs (
-          buildInputs ++ qtBuildInputs ++ [ pkgs.qt6.wrapQtAppsHook ]
-        );
-        devShells.depends = (mkDevShell nativeBuildInputs qtBuildInputs).overrideAttrs (oldAttrs: {
+        devShells.default = mkDevShell nativeBuildInputs buildInputs;
+        devShells.depends = (mkDevShell nativeBuildInputs).overrideAttrs (oldAttrs: {
           # Set these to force depends capnp to also use clang, otherwise it
           # fails when looking for the default (gcc/g++)
           build_CC = "clang";

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,6 @@
             pyzmq
             pycapnp
             requests
-            vulture
           ]
           ++ lib.optionals isLinux [
             bcc

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
           let
             moldStdenv = if isLinux then pkgs.stdenvAdapters.useMoldLinker llvmStdenv else llvmStdenv;
           in
-            pkgs.ccacheStdenv.override { stdenv = moldStdenv; };
+          pkgs.ccacheStdenv.override { stdenv = moldStdenv; };
 
         pythonEnv = python.withPackages (
           ps:
@@ -146,6 +146,7 @@
             packages = [
               clang-tidy-diff
               pkgs.codespell
+              pkgs.doxygen
               pkgs.hexdump
               pkgs.include-what-you-use
               pkgs.ruff

--- a/flake.nix
+++ b/flake.nix
@@ -17,20 +17,6 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            (final: prev: {
-              capnproto = prev.capnproto.overrideAttrs (oldAttrs: rec {
-                version = "1.3.0";
-                src = prev.fetchFromGitHub {
-                  owner = "capnproto";
-                  repo = "capnproto";
-                  rev = "v${version}";
-                  hash = "sha256-fvZzNDBZr73U+xbj1LhVj1qWZyNmblKluh7lhacV+6I=";
-                };
-                patches = [ ];
-              });
-            })
-          ];
         };
         inherit (pkgs) lib;
         inherit (pkgs.stdenv) isLinux isDarwin;
@@ -156,16 +142,15 @@
             CMAKE_EXPORT_COMPILE_COMMANDS = 1;
             LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.capnproto ];
             LOCALE_ARCHIVE = lib.optionalString isLinux "${pkgs.glibcLocales}/lib/locale/locale-archive";
+            # Force depends capnp to also use clang, otherwise it fails when
+            # looking for the default (gcc/g++)
+            build_CC = "clang";
+            build_CXX = "clang++";
           };
       in
       {
         devShells.default = mkDevShell nativeBuildInputs buildInputs;
-        devShells.depends = (mkDevShell nativeBuildInputs [ ]).overrideAttrs (oldAttrs: {
-          # Set these to force depends capnp to also use clang, otherwise it
-          # fails when looking for the default (gcc/g++)
-          build_CC = "clang";
-          build_CXX = "clang++";
-        });
+        devShells.depends = mkDevShell nativeBuildInputs [ ];
         formatter = pkgs.nixfmt-tree;
       }
     );

--- a/scripts/build-depends.sh
+++ b/scripts/build-depends.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd bitcoin
+
+# Nix sets CC/CXX to bare names (e.g. 'clang'), relying on PATH. The depends
+# Makefile substitutes these into toolchain.cmake, but cmake's find_program
+# searches system dirs before PATH, so a bare 'clang' resolves to the system
+# compiler instead of the Nix one. This causes glibc version mismatches:
+# objects compiled against Nix's newer glibc headers reference fortified
+# symbols (e.g. __inet_pton_chk) absent from the runner's older glibc.
+NIX_CC=$(command -v "$CC")
+NIX_CXX=$(command -v "$CXX")
+
+HOST_TRIPLET=$(./depends/config.guess)
+
+make -C depends "-j$(nproc)" NO_QT=1 \
+    CC="$NIX_CC" CXX="$NIX_CXX" \
+    build_CC="$NIX_CC" build_CXX="$NIX_CXX"
+
+cmake -B build --toolchain "depends/$HOST_TRIPLET/toolchain.cmake"
+cmake --build build "-j$(nproc)"
+ccache --show-stats

--- a/scripts/build-systemlibs.sh
+++ b/scripts/build-systemlibs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CORES=${1:?usage: build-systemlibs.sh <cores> [cmake_flags...]}
+shift
+CMAKE_FLAGS=("$@")
+
+cd bitcoin
+cmake -B build \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    --preset dev-mode \
+    -DBUILD_GUI=OFF \
+    "${CMAKE_FLAGS[@]}"
+cmake --build build "-j$CORES"
+ccache --show-stats

--- a/scripts/patchelf-releases.sh
+++ b/scripts/patchelf-releases.sh
@@ -1,0 +1,24 @@
+INTERP="@interp@"
+
+if [ -z "${PREVIOUS_RELEASES_DIR:-}" ]; then
+  echo "error: PREVIOUS_RELEASES_DIR is not set" >&2
+  exit 1
+fi
+
+if [ ! -f "$INTERP" ]; then
+  echo "error: interpreter not found: $INTERP" >&2
+  exit 1
+fi
+
+echo "Using interpreter: $INTERP"
+
+count=0
+while IFS= read -r -d '' bin; do
+  if file "$bin" | grep -q 'ELF.*dynamically linked'; then
+    patchelf --set-interpreter "$INTERP" "$bin"
+    echo "  patched: ${bin#"$PREVIOUS_RELEASES_DIR"/}"
+    count=$((count + 1))
+  fi
+done < <(find "$PREVIOUS_RELEASES_DIR" -path '*/bin/*' -type f -print0)
+
+echo "Patched $count binaries."


### PR DESCRIPTION
- Patches dynamically linked ELF binaries under $PREVIOUS_RELEASES_DIR
to use the Nix glibc interpreter, so previous Bitcoin Core releases
can run on NixOS.

- Set up the mold adapter to work without manual `-fuse-ld` config

- remove QT from shell (bloats linker paths, slows down linking)

- remove vulture + add doxygen